### PR TITLE
removed core urls and added temporary solution

### DIFF
--- a/server/core/templates/start_view.html
+++ b/server/core/templates/start_view.html
@@ -11,7 +11,7 @@
 		<p>Es gibt noch nichts zu sehen, aber es funktioniert</p>
 		<br>
 
-		<p>zum Backend: <a href={% url 'backend' %}>Django Admin</a></p>
+		<p>zum Backend: <a href='/admin/'>Django Admin</a></p>
 
 	</body>
 </html>

--- a/server/core/urls.py
+++ b/server/core/urls.py
@@ -1,5 +1,0 @@
-from django.urls import path, include
-
-urlpatterns = [
-    path('', include('server.urls'))
-]


### PR DESCRIPTION
wieso auch immer `{% url <pattername> %}` funktioniert noch nicht, muss es in Zukunft aber